### PR TITLE
Remove 'px' from height/width attributes.

### DIFF
--- a/code/SVGTemplate.php
+++ b/code/SVGTemplate.php
@@ -195,11 +195,11 @@ class SVGTemplate extends ViewableData
         }
 
         if ($this->width) {
-            $root->setAttribute('width',  $this->width . 'px');
+            $root->setAttribute('width', $this->width);
         }
 
         if ($this->height) {
-            $root->setAttribute('height', $this->height . 'px');
+            $root->setAttribute('height', $this->height);
         }
 
         if ($this->extra_classes) {


### PR DESCRIPTION
'px' is not needed to define pixel sizes in attributes, and removing 'px' allows
users to define sizes in valid units other than pixels, for example percentages
or ems.